### PR TITLE
Various LuaJ fixes

### DIFF
--- a/src/main/java/li/cil/repack/org/luaj/vm2/LuaClosure.java
+++ b/src/main/java/li/cil/repack/org/luaj/vm2/LuaClosure.java
@@ -122,10 +122,6 @@ public class LuaClosure extends LuaFunction {
 		return s_metatable;
 	}
 
-	public String tojstring() {
-		return "function: " + p.toString();
-	}
-
 	public final LuaValue call() {
 		LuaValue[] stack = new LuaValue[p.maxstacksize];
 		for (int i = 0; i < p.numparams; ++i)

--- a/src/main/java/li/cil/repack/org/luaj/vm2/LuaDouble.java
+++ b/src/main/java/li/cil/repack/org/luaj/vm2/LuaDouble.java
@@ -89,6 +89,10 @@ public class LuaDouble extends LuaNumber {
 		return ((int) (l >> 32)) + (int) l;
 	}
 
+	public boolean isNegative() {
+		return Double.doubleToRawLongBits(v) < 0;
+	}
+
 	public boolean islong() {
 		return v == (long) v;
 	}
@@ -416,7 +420,7 @@ public class LuaDouble extends LuaNumber {
 		}
 		*/
 		if (Double.isNaN(v))
-			return JSTR_NAN;
+			return (isNegative() ? "-" : "") + JSTR_NAN;
 		if (Double.isInfinite(v))
 			return (v < 0 ? JSTR_NEGINF : JSTR_POSINF);
 		return Double.toString(v);

--- a/src/main/java/li/cil/repack/org/luaj/vm2/LuaFunction.java
+++ b/src/main/java/li/cil/repack/org/luaj/vm2/LuaFunction.java
@@ -62,10 +62,6 @@ abstract public class LuaFunction extends LuaValue {
 		return s_metatable;
 	}
 
-	public String tojstring() {
-		return "function: " + classnamestub();
-	}
-
 	public LuaString strvalue() {
 		return valueOf(tojstring());
 	}

--- a/src/main/java/li/cil/repack/org/luaj/vm2/LuaValue.java
+++ b/src/main/java/li/cil/repack/org/luaj/vm2/LuaValue.java
@@ -560,7 +560,7 @@ abstract public class LuaValue extends Varargs {
 	 * @see #TSTRING
 	 */
 	public String tojstring() {
-		return typename() + ": " + Integer.toHexString(hashCode());
+		return typename() + ": 0x" + Integer.toHexString(hashCode());
 	}
 
 	/** Convert to userdata instance, or null.
@@ -1194,7 +1194,7 @@ abstract public class LuaValue extends Varargs {
 	 * @throws LuaError in all cases
 	 */
 	protected LuaValue argerror(String expected) {
-		throw new LuaError("bad argument: " + expected + " expected, got " + typename());
+		throw new LuaError("bad argument (" + expected + " expected, got " + typename() + ")");
 	}
 
 	/** 
@@ -1204,7 +1204,7 @@ abstract public class LuaValue extends Varargs {
 	 * @throws LuaError in all cases
 	 */
 	public static LuaValue argerror(int iarg, String msg) {
-		throw new LuaError("bad argument #" + iarg + ": " + msg);
+		throw new LuaError("bad argument #" + iarg + " (" + msg + ")");
 	}
 
 	/** 

--- a/src/main/java/li/cil/repack/org/luaj/vm2/compiler/FuncState.java
+++ b/src/main/java/li/cil/repack/org/luaj/vm2/compiler/FuncState.java
@@ -93,7 +93,7 @@ public class FuncState extends Constants {
 		int i;
 		for (i = bl.firstlabel; i < ll_n; i++) {
 			if (label.eq_b(ll[i].name)) {
-				String msg = ls.L.pushfstring("label '" + label + " already defined on line " + ll[i].line);
+				String msg = ls.L.pushfstring("label '" + label + "' already defined on line " + ll[i].line);
 				ls.semerror(msg);
 			}
 		}

--- a/src/main/java/li/cil/repack/org/luaj/vm2/compiler/LexState.java
+++ b/src/main/java/li/cil/repack/org/luaj/vm2/compiler/LexState.java
@@ -131,13 +131,13 @@ public class LexState extends Constants {
 	byte decpoint; /* locale decimal point */
 
 	/* ORDER RESERVED */
-	final static String luaX_tokens[] = { "and", "break", "do", "else", "elseif", "end", "false", "for", "function", "goto", "if", "in", "local", "nil", "not", "or", "repeat", "return", "then", "true", "until", "while", "..", "...", "==", ">=", "<=", "~=", "::", "<eos>", "<number>", "<name>", "<string>", "<eof>", };
+	final static String luaX_tokens[] = { "and", "break", "do", "else", "elseif", "end", "false", "for", "function", "goto", "if", "in", "local", "nil", "not", "or", "repeat", "return", "then", "true", "until", "while", "..", "...", "==", ">=", "<=", "~=", "::", "<eof>", "<number>", "<name>", "<string>" };
 
 	final static int
 	/* terminal symbols denoted by reserved words */
 	TK_AND = 257, TK_BREAK = 258, TK_DO = 259, TK_ELSE = 260, TK_ELSEIF = 261, TK_END = 262, TK_FALSE = 263, TK_FOR = 264, TK_FUNCTION = 265, TK_GOTO = 266, TK_IF = 267, TK_IN = 268, TK_LOCAL = 269, TK_NIL = 270, TK_NOT = 271, TK_OR = 272, TK_REPEAT = 273, TK_RETURN = 274, TK_THEN = 275, TK_TRUE = 276, TK_UNTIL = 277, TK_WHILE = 278,
 			/* other terminal symbols */
-			TK_CONCAT = 279, TK_DOTS = 280, TK_EQ = 281, TK_GE = 282, TK_LE = 283, TK_NE = 284, TK_DBCOLON = 285, TK_EOS = 286, TK_NUMBER = 287, TK_NAME = 288, TK_STRING = 289;
+			TK_CONCAT = 279, TK_DOTS = 280, TK_EQ = 281, TK_GE = 282, TK_LE = 283, TK_NE = 284, TK_DBCOLON = 285, TK_EOF = 286, TK_NUMBER = 287, TK_NAME = 288, TK_STRING = 289;
 
 	final static int FIRST_RESERVED = TK_AND;
 	final static int NUM_RESERVED = TK_WHILE + 1 - FIRST_RESERVED;
@@ -261,7 +261,7 @@ public class LexState extends Constants {
 	void setinput(LuaC.CompileState L, int firstByte, InputStream z, LuaString source) {
 		this.decpoint = '.';
 		this.L = L;
-		this.lookahead.token = TK_EOS; /* no look-ahead token */
+		this.lookahead.token = TK_EOF; /* no look-ahead token */
 		this.z = z;
 		this.fs = null;
 		this.linenumber = 1;
@@ -399,7 +399,7 @@ public class LexState extends Constants {
 		for (boolean endloop = false; !endloop;) {
 			switch (current) {
 			case EOZ:
-				lexerror((seminfo != null) ? "unfinished long string" : "unfinished long comment", TK_EOS);
+				lexerror((seminfo != null) ? "unfinished long string" : "unfinished long comment", TK_EOF);
 				break; /* to avoid warnings */
 			case '[': {
 				if (skip_sep() == sep) {
@@ -463,7 +463,7 @@ public class LexState extends Constants {
 		while (current != del) {
 			switch (current) {
 			case EOZ:
-				lexerror("unfinished string", TK_EOS);
+				lexerror("unfinished string", TK_EOF);
 				continue; /* to avoid warnings */
 			case '\n':
 			case '\r':
@@ -663,7 +663,7 @@ public class LexState extends Constants {
 				return TK_NUMBER;
 			}
 			case EOZ: {
-				return TK_EOS;
+				return TK_EOF;
 			}
 			default: {
 				if (isspace(current)) {
@@ -698,15 +698,15 @@ public class LexState extends Constants {
 
 	void next() {
 		lastline = linenumber;
-		if (lookahead.token != TK_EOS) { /* is there a look-ahead token? */
+		if (lookahead.token != TK_EOF) { /* is there a look-ahead token? */
 			t.set(lookahead); /* use this one */
-			lookahead.token = TK_EOS; /* and discharge it */
+			lookahead.token = TK_EOF; /* and discharge it */
 		} else
 			t.token = llex(t.seminfo); /* read next token */
 	}
 
 	void lookahead() {
-		_assert(lookahead.token == TK_EOS);
+		_assert(lookahead.token == TK_EOF);
 		lookahead.token = llex(lookahead.seminfo);
 	}
 
@@ -819,8 +819,8 @@ public class LexState extends Constants {
 	------------------------------------------------------------------------*/
 
 	void anchor_token() {
-		/* last token from outer function must be EOS */
-		_assert(fs != null || t.token == TK_EOS);
+		/* last token from outer function must be EOF */
+		_assert(fs != null || t.token == TK_EOF);
 		if (t.token == TK_NAME || t.token == TK_STRING) {
 			LuaString ts = t.seminfo.ts;
 			// TODO: is this necessary?
@@ -1567,7 +1567,7 @@ public class LexState extends Constants {
 		case TK_ELSE:
 		case TK_ELSEIF:
 		case TK_END:
-		case TK_EOS:
+		case TK_EOF:
 			return true;
 		case TK_UNTIL:
 			return withuntil;
@@ -2076,7 +2076,7 @@ public class LexState extends Constants {
 		fs.newupvalue(envn, v); /* ...set environment upvalue */
 		next(); /* read first token */
 		statlist(); /* parse main body */
-		check(TK_EOS);
+		check(TK_EOF);
 		close_func();
 	}
 

--- a/src/main/java/li/cil/repack/org/luaj/vm2/lib/BaseLib.java
+++ b/src/main/java/li/cil/repack/org/luaj/vm2/lib/BaseLib.java
@@ -367,12 +367,13 @@ public class BaseLib extends TwoArgFunction implements ResourceFinder {
 	// "tostring", // (e) -> value
 	static final class tostring extends LibFunction {
 		public LuaValue call(LuaValue arg) {
-			LuaValue h = arg.metatag(TOSTRING);
-			if (!h.isnil())
-				return h.call(arg);
-			LuaValue v = arg.tostring();
-			if (!v.isnil())
-				return v;
+			LuaValue t = arg.metatag(TOSTRING);
+			if (!t.isnil()) {
+				LuaValue v = t.call(arg);
+				LuaValue h = v.tostring();
+				return !h.isnil() ? h : v;
+			} else if (arg instanceof LuaString) // Avoid UTF-8 Handling/Corruption
+				return arg;
 			return valueOf(arg.tojstring());
 		}
 	}

--- a/src/main/java/li/cil/repack/org/luaj/vm2/lib/LibFunction.java
+++ b/src/main/java/li/cil/repack/org/luaj/vm2/lib/LibFunction.java
@@ -137,10 +137,6 @@ abstract public class LibFunction extends LuaFunction {
 	/** Default constructor for use by subclasses */
 	protected LibFunction() {}
 
-	public String tojstring() {
-		return name != null ? name : super.tojstring();
-	}
-
 	/** 
 	 * Bind a set of library functions.  
 	 * <p>

--- a/src/main/java/li/cil/repack/org/luaj/vm2/lib/jse/JseMathLib.java
+++ b/src/main/java/li/cil/repack/org/luaj/vm2/lib/jse/JseMathLib.java
@@ -122,9 +122,13 @@ public class JseMathLib extends li.cil.repack.org.luaj.vm2.lib.MathLib {
 		}
 	}
 
-	static final class log extends UnaryOp {
-		protected double call(double d) {
-			return Math.log(d);
+	static final class log extends LibFunction {
+		public LuaValue call(LuaValue x) {
+			return valueOf(Math.log(x.checkdouble()));
+		}
+
+		public LuaValue call(LuaValue x, LuaValue base) {
+			return valueOf(Math.log(x.checkdouble()) / Math.log(base.checkdouble()));
 		}
 	}
 


### PR DESCRIPTION
There's a couple of things I'd like your input on before you'd accept:
The strx2number function (LuaString.java) and the new string.rep (StringLib.java)

**Changelog:**
Remove custom tojstring from LuaClosure, LuaFunction, and LibFunction
Add '0x' to LuaValue's tojstring to match Lua

Trash the old string to number conversion code and port strx2number
Handle '+' signs when converting from strings to numbers
Allow showing the sign of a NaN value

Change the error message formatting to match Lua
Add a missing end single-quote to an error message
Rename TK_EOS and <eos> to TK_EOF and <eof> to match Lua
Fix __tostring handling in tostring
Clean string.format and fix %s only accepting strings
Support seperators in string.rep
Fix math.log not accepting a second argument

Restore a bit of LuaJ code, seems an old bug got fixed
